### PR TITLE
Remove erasableSyntaxOnly in tsconfigs

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -19,7 +19,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -17,7 +17,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
## Summary
- remove invalid `erasableSyntaxOnly` compiler option
- enable `exactOptionalPropertyTypes` for stricter checking

## Testing
- `npm install`
- `npx tsc -b`

------
https://chatgpt.com/codex/tasks/task_e_683ff61108548322af5e49e0ecde8766